### PR TITLE
Added missing composer dependency (task #7119)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "robo-tasks",
     "license": "MIT",
     "require": {
-        "qobo/qobo-robo": "^2.0"
+        "qobo/qobo-robo": "^2.0",
+        "symfony/filesystem": "^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "*",


### PR DESCRIPTION
Ideally we should get rid of it altogether is we are only
using a small set of the functionality (recursive rmdir and
recursive mkdir).  But we bring half of the Symfony framework
for that.